### PR TITLE
Fix infinite loop in insertRowsAtIndexPaths:withRowAnimation:

### DIFF
--- a/PDGesturedTableView.m
+++ b/PDGesturedTableView.m
@@ -306,7 +306,7 @@
 }
 
 - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation {
-    [self insertRowsAtIndexPaths:indexPaths withRowAnimation:animation];
+    [super insertRowsAtIndexPaths:indexPaths withRowAnimation:animation];
     [self showOrHideBackgroundView];
 }
 


### PR DESCRIPTION
As described in title.
Just found this little bug while reading the source code.

Nice work! :+1: 
